### PR TITLE
use a custom CMakePresets.json file in case of cross compiling for osx-arm64

### DIFF
--- a/recipe/CMakePresetCrossCompileAppleSilicon.json
+++ b/recipe/CMakePresetCrossCompileAppleSilicon.json
@@ -1,0 +1,21 @@
+{
+    "version": 3,
+    "configurePresets": [
+      {
+        "name": "darwin-conda-release",
+        "hidden": true,
+        "generator": "Unix Makefiles",
+        "cacheVariables": {
+          "ARCTICDB_USING_CONDA": "ON",
+          "CMAKE_MAKE_PROGRAM": "make",
+          "STATIC_LINK_STD_LIB": "OFF",
+          "CMAKE_BUILD_TYPE" : "RelWithDebInfo"
+        },
+        "environment": {"cmakepreset_expected_host_system": "Darwin"}
+      }
+    ],
+    "buildPresets": [
+      {"name": "darwin-conda-release",      "configurePreset": "darwin-conda-release",      "targets": "arcticdb_ext" }
+    ]
+}
+  

--- a/recipe/CMakePresetCrossCompileAppleSilicon.json
+++ b/recipe/CMakePresetCrossCompileAppleSilicon.json
@@ -3,7 +3,7 @@
     "configurePresets": [
       {
         "name": "darwin-conda-release",
-        "hidden": true,
+        "hidden": false,
         "generator": "Unix Makefiles",
         "cacheVariables": {
           "ARCTICDB_USING_CONDA": "ON",

--- a/recipe/CMakePresetCrossCompileAppleSilicon.json
+++ b/recipe/CMakePresetCrossCompileAppleSilicon.json
@@ -12,10 +12,23 @@
           "CMAKE_BUILD_TYPE" : "RelWithDebInfo"
         },
         "environment": {"cmakepreset_expected_host_system": "Darwin"}
+      },
+      {
+        "name": "darwin-conda-debug",
+        "hidden": false,
+        "generator": "Unix Makefiles",
+        "cacheVariables": {
+          "ARCTICDB_USING_CONDA": "ON",
+          "CMAKE_MAKE_PROGRAM": "make",
+          "STATIC_LINK_STD_LIB": "OFF",
+          "CMAKE_BUILD_TYPE" : "Debug"
+        },
+        "environment": {"cmakepreset_expected_host_system": "Darwin"}
       }
     ],
     "buildPresets": [
-      {"name": "darwin-conda-release",      "configurePreset": "darwin-conda-release",      "targets": "arcticdb_ext" }
+      {"name": "darwin-conda-release",      "configurePreset": "darwin-conda-release",      "targets": "arcticdb_ext" },
+      {"name": "darwin-conda-debug",      "configurePreset": "darwin-conda-debug",      "targets": "arcticdb_ext" }
     ]
 }
   

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,10 @@ export ARCTICDB_USING_CONDA=1
 export CMAKE_BUILD_PARALLEL_LEVEL=1
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
-  # Get an updated config.sub and config.guess
+
+
+
+  # Get an updated config.sub and config.guess  
   # (see https://conda-forge.org/docs/maintainer/knowledge_base.html#cross-compilation)
   cp $BUILD_PREFIX/share/gnuconfig/config.* .
 
@@ -14,6 +17,19 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
   # in order to get a usable binary to compile the protobuf files.
   rm $PREFIX/bin/protoc
   ln -s $BUILD_PREFIX/bin/protoc $PREFIX/bin/protoc
+
+  # if we cross compile for apple 
+  if [[ "$target_platform" == "osx-arm64" ]]; then
+    echo "Cross compiling for apple silicon"
+
+    # when cross compiling for apple silicon, we absolutely need to make sure
+    # that there is no hard coded compiler in the cmake-preset / cmake-config.
+    # while https://github.com/man-group/ArcticDB/pull/662 is not merged, we
+    # need use a custom cmake preset file for apple silicon.
+    cp $RECIPE_DIR/CMakePresetCrossCompileAppleSilicon.json $SRC_DIR/cpp/CMakePresets.json
+
+  fi
+
 fi
 
 $PYTHON -m pip install . -vv --no-build-isolation --no-deps

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,9 +6,6 @@ export ARCTICDB_USING_CONDA=1
 export CMAKE_BUILD_PARALLEL_LEVEL=1
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
-
-
-
   # Get an updated config.sub and config.guess  
   # (see https://conda-forge.org/docs/maintainer/knowledge_base.html#cross-compilation)
   cp $BUILD_PREFIX/share/gnuconfig/config.* .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,7 @@ export ARCTICDB_USING_CONDA=1
 export CMAKE_BUILD_PARALLEL_LEVEL=1
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
+
   # Get an updated config.sub and config.guess  
   # (see https://conda-forge.org/docs/maintainer/knowledge_base.html#cross-compilation)
   cp $BUILD_PREFIX/share/gnuconfig/config.* .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   # is not available for Windows on conda-forge
   # See: https://github.com/conda-forge/folly-feedstock/pull/98
   skip: true  # [win]
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

When cross-compiling for apple-silicon, we absolutely need to make sure that there is no hard-coded compiler in the cmake-preset / cmake-config. While https://github.com/man-group/ArcticDB/pull/662 is not merged, we need use a custom cmake preset file for apple silicon and overwrite the existing one.