### PR TITLE
Use default compilers for darwin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,10 @@ source:
   sha256: ede72b1a1f6430ce346f9374742643c217506f7034d801e02c38cdde18ec93d8
 
   patches:
+  # When cross-compiling for apple-silicon, we absolutely need to make sure
+  # that there is no hard-coded compiler in the cmake-preset / cmake-config.
+  # While man-group/ArcticDB#662 is not merged,
+  # we use a patch to remove the hard coded clang
     - patches/patch_compiler_for_darwin.patch 
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,12 +9,15 @@ source:
   url: https://github.com/man-group/ArcticDB/archive/refs/tags/v{{ version }}.tar.gz
   sha256: ede72b1a1f6430ce346f9374742643c217506f7034d801e02c38cdde18ec93d8
 
+  patches:
+    - patches/patch_compiler_for_darwin.patch 
+
 build:
   # We skip the build on Windows because one of the dependencies (folly)
   # is not available for Windows on conda-forge
   # See: https://github.com/conda-forge/folly-feedstock/pull/98
   skip: true  # [win]
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipe/patches/patch_compiler_for_darwin.patch
+++ b/recipe/patches/patch_compiler_for_darwin.patch
@@ -1,0 +1,13 @@
+diff --git a/cpp/CMakePresets.json b/cpp/CMakePresets.json
+index 8379d60..e3c1869 100644
+--- a/cpp/CMakePresets.json
++++ b/cpp/CMakePresets.json
+@@ -112,8 +112,6 @@
+       "generator": "Unix Makefiles",
+       "cacheVariables": {
+         "CMAKE_MAKE_PROGRAM": "make",
+-        "CMAKE_C_COMPILER": "clang",
+-        "CMAKE_CXX_COMPILER": "clang",
+         "STATIC_LINK_STD_LIB": "OFF"
+       },
+       "environment": {"cmakepreset_expected_host_system": "Darwin"}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
When cross-compiling for apple-silicon, we absolutely need to make sure that there is no hard-coded compiler in the cmake-preset / cmake-config. While https://github.com/man-group/ArcticDB/pull/662 is not merged, we use a patch to remove the hard coded `clang`
