### PR TITLE
[ci skip] Make the migration bot also target `rc` and `libevent-2.1.10`

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,7 @@ github:
   branch_name: main
   tooling_branch_name: main
 test: native_and_emulated
+bot:
+  abi_migration_branches:
+    - rc
+    - libevent-2.1.10


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---
This prevents porting some PRs merged on `main` to `rc` and to `libevent-2.1.0`

For the bot configuration, see: https://conda-forge.org/docs/maintainer/conda_forge_yml.html#bot