### PR TITLE
Build using all the cores

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 export ARCTICDB_USING_CONDA=1
-# Compiling ArcticDB with all cores might freeze machines due to swapping.
-# We build with only 1 core to prevent these freezes from happening.
-export CMAKE_BUILD_PARALLEL_LEVEL=1
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
   # Get an updated config.sub and config.guess


### PR DESCRIPTION
With recent changes to reduce memory usage for the compilation for 4.3.0rc0, it might be possible to build ArcticDB using all the cores of the CI machines which have two logical cores.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
