### PR TITLE
Adopt global pinnings for azure

### DIFF
--- a/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpython.yaml
@@ -1,5 +1,11 @@
 aws_sdk_cpp:
 - 1.11.329
+azure_core_cpp:
+- 1.12.0
+azure_identity_cpp:
+- 1.8.0
+azure_storage_blobs_cpp:
+- 12.11.0
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.8.____cpython.yaml
@@ -1,5 +1,11 @@
 aws_sdk_cpp:
 - 1.11.329
+azure_core_cpp:
+- 1.12.0
+azure_identity_cpp:
+- 1.8.0
+azure_storage_blobs_cpp:
+- 12.11.0
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpython.yaml
@@ -1,5 +1,11 @@
 aws_sdk_cpp:
 - 1.11.329
+azure_core_cpp:
+- 1.12.0
+azure_identity_cpp:
+- 1.8.0
+azure_storage_blobs_cpp:
+- 12.11.0
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -1,5 +1,11 @@
 aws_sdk_cpp:
 - 1.11.329
+azure_core_cpp:
+- 1.12.0
+azure_identity_cpp:
+- 1.8.0
+azure_storage_blobs_cpp:
+- 12.11.0
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/migrations/azure_core_cpp1120.yaml
+++ b/.ci_support/migrations/azure_core_cpp1120.yaml
@@ -1,0 +1,21 @@
+migrator_ts: 1718824596
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+  commit_message: Pin azure-core-cpp 1.12.0
+
+azure_core_cpp:
+  - 1.12.0
+azure_identity_cpp:
+  - 1.8.0
+azure_storage_blobs_cpp:
+  - 12.11.0
+azure_storage_common_cpp:
+  - 12.6.0
+azure_storage_files_datalake_cpp:
+  - 12.10.0
+azure_storage_files_shares_cpp:
+  - 12.9.0
+azure_storage_queues_cpp:
+  - 12.2.0

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpython.yaml
@@ -4,6 +4,12 @@ MACOSX_SDK_VERSION:
 - '11.0'
 aws_sdk_cpp:
 - 1.11.329
+azure_core_cpp:
+- 1.12.0
+azure_identity_cpp:
+- 1.8.0
+azure_storage_blobs_cpp:
+- 12.11.0
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpython.yaml
@@ -4,6 +4,12 @@ MACOSX_SDK_VERSION:
 - '11.0'
 aws_sdk_cpp:
 - 1.11.329
+azure_core_cpp:
+- 1.12.0
+azure_identity_cpp:
+- 1.8.0
+azure_storage_blobs_cpp:
+- 12.11.0
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -4,6 +4,12 @@ MACOSX_SDK_VERSION:
 - '11.0'
 aws_sdk_cpp:
 - 1.11.329
+azure_core_cpp:
+- 1.12.0
+azure_identity_cpp:
+- 1.8.0
+azure_storage_blobs_cpp:
+- 12.11.0
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -4,6 +4,12 @@ MACOSX_SDK_VERSION:
 - '11.0'
 aws_sdk_cpp:
 - 1.11.329
+azure_core_cpp:
+- 1.12.0
+azure_identity_cpp:
+- 1.8.0
+azure_storage_blobs_cpp:
+- 12.11.0
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -4,6 +4,12 @@ MACOSX_SDK_VERSION:
 - '11.0'
 aws_sdk_cpp:
 - 1.11.329
+azure_core_cpp:
+- 1.12.0
+azure_identity_cpp:
+- 1.8.0
+azure_storage_blobs_cpp:
+- 12.11.0
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -4,6 +4,12 @@ MACOSX_SDK_VERSION:
 - '11.0'
 aws_sdk_cpp:
 - 1.11.329
+azure_core_cpp:
+- 1.12.0
+azure_identity_cpp:
+- 1.8.0
+azure_storage_blobs_cpp:
+- 12.11.0
 c_compiler:
 - clang
 c_compiler_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
   skip: true  # [osx and py<39]
   # not ready yet; needs to unpin pybind11
   skip: true  # [py>=312]
-  number: 0
+  number: 1
 
   entry_points:
     - arcticdb_update_storage = arcticdb.scripts.update_storage:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,10 +91,6 @@ requirements:
   # See install_requires: https://github.com/man-group/ArcticDB/blob/master/setup.cfg
     - glog
     - python
-    # To keep in sync with `install_requires` in setup.cfg.
-    # Enforce the same major version of NumPy at runtime.
-    # See: https://conda-forge.org/docs/maintainer/knowledge_base/#building-against-numpy
-    - {{ pin_compatible('numpy') }}
     - pandas
     - attrs
     - decorator


### PR DESCRIPTION
See https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/6003;

migrator failed with:
```
Error running check-solvable in container - error ValueError raised:
"Very odd pinning: pin_compatible('numpy')! Package numpy not found in host {}!"
```
not 100% sure what happened there, but we don't need it in run anyway; the run-export of numpy takes care of that.