### PR TITLE
[libevent-2.1.10] Adapt pins for `azure_core_cpp==1.11.x`

### DIFF
--- a/.ci_support/linux_64_nodejs18numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_nodejs18numpy1.22python3.9.____cpython.yaml
@@ -1,11 +1,11 @@
 aws_sdk_cpp:
 - 1.10.57
 azure_core_cpp:
-- 1.10.2
+- 1.11.1
 azure_identity_cpp:
-- 1.5.1
+- '*'
 azure_storage_blobs_cpp:
-- 12.9.0
+- '*'
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_64_nodejs20numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_nodejs20numpy1.22python3.9.____cpython.yaml
@@ -1,11 +1,11 @@
 aws_sdk_cpp:
 - 1.10.57
 azure_core_cpp:
-- 1.10.2
+- 1.11.1
 azure_identity_cpp:
-- 1.5.1
+- '*'
 azure_storage_blobs_cpp:
-- 12.9.0
+- '*'
 c_compiler:
 - gcc
 c_compiler_version:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,9 +7,15 @@ libevent:
 lmdb:
   - "0.9.22"
 # Pin specific versions of some dependencies which we know are supported
-# by a previous build, `linux-64_arcticdb-4.0.0-py39h1278ff5_2`.
 # Pinning less is not sufficient, pinning more would constrain the
 # environment too much.
+#
+# Those were originally pinned based on a previous build's
+# (namely `linux-64_arcticdb-4.0.0-py39h1278ff5_2`) but have to
+# sporadically be updated to newer versions.
+#
+# For an instance of an update, see:
+# https://github.com/conda-forge/arcticdb-feedstock/pull/239
 folly:
   - "2023.09.25.00"
 xxhash:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -17,8 +17,8 @@ xxhash:
 aws_sdk_cpp:
   - "1.10.57"
 azure_core_cpp:
-  - "1.10.2"
+  - "1.11.1"
 azure_identity_cpp:
-  - "1.5.1"
+  - "*"
 azure_storage_blobs_cpp:
-  - "12.9.0"
+  - "*"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   # Only build for Linux and Python 3.9
   skip: true  # [not linux]
   skip: true  # [not py==39]
-  number: 0
+  number: 1
 
   entry_points:
     - arcticdb_update_storage = arcticdb.scripts.update_storage:main


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Transition for `azure_core_cpp==1.11.x`

See #236.

---

The Azure SDK for C++ is highly constrained: `run_exports` exists on patch versions of their libraries because (IIRC) they have been observed not be to ABI compatible on minor versions. Since there are a few builds of them, and since they depends on `libcurl` and `openssl`, this further constrains the problem.

Pinning `azure_core_cpp==1.11.1` allows satisfying the current know constraints, i.e.:
 - use `azure_core_cpp==1.11.x`
 - at least one build of other Azure SDK for C++ libraries exists for it
 - compatible with the known constrains of `libcurl` and `openssl` for the alternative build
