### PR TITLE
[rc] remove cap for libcxx

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,9 +47,6 @@ requirements:
     - libprotobuf <4                          # [build_platform != target_platform]
     - pkg-config                              # [build_platform != target_platform]
     - gnuconfig                               # [build_platform != target_platform]
-    # TODO: Resolve the issue with libcxx 18.1.8, only observed for osx_64
-    # https://github.com/conda-forge/libcxx-feedstock/issues/162
-    - libcxx <18  # [osx and build_platform == target_platform]
   host:
   # This environment specification must be maintained in sync with the one upstream:
   # See: https://github.com/man-group/ArcticDB/blob/master/environment_unix.yml
@@ -78,9 +75,6 @@ requirements:
     - gflags
     - msgpack-c
     - aws-sdk-cpp
-    # TODO: Resolve the issue with libcxx 18.1.8, only observed for osx_64
-    # https://github.com/conda-forge/libcxx-feedstock/issues/162
-    - libcxx <18  # [osx and build_platform == target_platform]
     - azure-core-cpp
     - azure-identity-cpp
     - azure-storage-blobs-cpp
@@ -100,9 +94,6 @@ requirements:
     - glog
     - gtest
     - benchmark
-    # TODO: Resolve the issue with libcxx 18.1.8, only observed for osx_64
-    # https://github.com/conda-forge/libcxx-feedstock/issues/162
-    - libcxx <18  # [osx and build_platform == target_platform]
   run:
   # This environment specification must be maintained in sync with the one upstream:
   # See: https://github.com/man-group/ArcticDB/blob/master/environment_unix.yml
@@ -125,9 +116,6 @@ requirements:
     - protobuf >=3.5.1
     - lmdb
     - packaging
-    # TODO: Resolve the issue with libcxx 18.1.8, only observed for osx_64
-    # https://github.com/conda-forge/libcxx-feedstock/issues/162
-    - libcxx <18  # [osx and build_platform == target_platform]
 test:
   requires:
   # This environment specification must be maintained in sync with the one upstream:
@@ -158,9 +146,6 @@ test:
   # Extra dependencies
     - pytest-rerunfailures
     - nodejs  # for npm
-    # TODO: Resolve the issue with libcxx 18.1.8, only observed for osx_64
-    # https://github.com/conda-forge/libcxx-feedstock/issues/162
-    - libcxx <18  # [osx and build_platform == target_platform]
   source_files:
     - python/tests
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ build:
   # TODO: the specific on python does not work for now, we need to investigate why.
   # skip: true  # [libevent == "2.1.10" and py>39]
   # skip: true  # [libevent == "2.1.10" and py<39]
-  number: 0
+  number: 1
 
   entry_points:
     - arcticdb_update_storage = arcticdb.scripts.update_storage:main


### PR DESCRIPTION
Remove them again now that https://github.com/conda-forge/libcxx-feedstock/pull/173 has landed

Thanks a lot to @jjerphan for figuring out the issue in https://github.com/conda-forge/libcxx-feedstock/pull/174!

~Trying to determine if https://github.com/conda-forge/libcxx-feedstock/issues/162 would be fixed if we [shipped](https://github.com/conda-forge/libcxx-feedstock/pull/163) libunwind on osx.~