### PR TITLE
[libevent-2.1.10] Add `lz4_c` as part of the build variants' definition

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,36 +8,36 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_aws_sdk_cpp1.10.57nodejs20numpy1.22python3.9.____cpython:
-        CONFIG: linux_64_aws_sdk_cpp1.10.57nodejs20numpy1.22python3.9.____cpython
+      linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs20numpy1.22python3.9.____cpython:
+        CONFIG: linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs20numpy1.22python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-        SHORT_CONFIG: linux_64_aws_sdk_cpp1.10.57nodejs20_hf50c9ebf2d
-      linux_64_aws_sdk_cpp1.10.57nodejs22numpy1.22python3.9.____cpython:
-        CONFIG: linux_64_aws_sdk_cpp1.10.57nodejs22numpy1.22python3.9.____cpython
+        SHORT_CONFIG: linux_64_aws_sdk_cpp1.10.57lz4_c1.1_heb7a1ad708
+      linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs22numpy1.22python3.9.____cpython:
+        CONFIG: linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs22numpy1.22python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-        SHORT_CONFIG: linux_64_aws_sdk_cpp1.10.57nodejs22_h0fa186704d
-      linux_64_aws_sdk_cpp1.11.210nodejs20numpy1.22python3.9.____cpython:
-        CONFIG: linux_64_aws_sdk_cpp1.11.210nodejs20numpy1.22python3.9.____cpython
+        SHORT_CONFIG: linux_64_aws_sdk_cpp1.10.57lz4_c1.1_h5701119b82
+      linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs20numpy1.22python3.9.____cpython:
+        CONFIG: linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs20numpy1.22python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-        SHORT_CONFIG: linux_64_aws_sdk_cpp1.11.210nodejs2_h87f18f0149
-      linux_64_aws_sdk_cpp1.11.210nodejs22numpy1.22python3.9.____cpython:
-        CONFIG: linux_64_aws_sdk_cpp1.11.210nodejs22numpy1.22python3.9.____cpython
+        SHORT_CONFIG: linux_64_aws_sdk_cpp1.11.210lz4_c1._h0372dab4c1
+      linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs22numpy1.22python3.9.____cpython:
+        CONFIG: linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs22numpy1.22python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-        SHORT_CONFIG: linux_64_aws_sdk_cpp1.11.210nodejs2_h34e53e0373
-      linux_64_aws_sdk_cpp_nodejs20numpy1.22python3.9.____cpython:
-        CONFIG: linux_64_aws_sdk_cpp_nodejs20numpy1.22python3.9.____cpython
+        SHORT_CONFIG: linux_64_aws_sdk_cpp1.11.210lz4_c1._hfb1e91060d
+      linux_64_aws_sdk_cpp_lz4_c1.9nodejs20numpy1.22python3.9.____cpython:
+        CONFIG: linux_64_aws_sdk_cpp_lz4_c1.9nodejs20numpy1.22python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-        SHORT_CONFIG: linux_64_aws_sdk_cpp_nodejs20numpy1_hb91c86fd44
-      linux_64_aws_sdk_cpp_nodejs22numpy1.22python3.9.____cpython:
-        CONFIG: linux_64_aws_sdk_cpp_nodejs22numpy1.22python3.9.____cpython
+        SHORT_CONFIG: linux_64_aws_sdk_cpp_lz4_c1.9nodejs_h09ac1bc605
+      linux_64_aws_sdk_cpp_lz4_c1.9nodejs22numpy1.22python3.9.____cpython:
+        CONFIG: linux_64_aws_sdk_cpp_lz4_c1.9nodejs22numpy1.22python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-        SHORT_CONFIG: linux_64_aws_sdk_cpp_nodejs22numpy1_h38eb6117cc
+        SHORT_CONFIG: linux_64_aws_sdk_cpp_lz4_c1.9nodejs_h9af9cbeebc
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs20numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs20numpy1.22python3.9.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- '*'
+- 1.10.57
 azure_core_cpp:
 - 1.11.1
 azure_identity_cpp:
@@ -71,7 +71,8 @@ xxhash:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - libevent
+- - lz4_c
+  - libevent
   - aws_sdk_cpp
   - azure_core_cpp
   - azure_identity_cpp

--- a/.ci_support/linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs22numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs22numpy1.22python3.9.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.11.210
+- 1.10.57
 azure_core_cpp:
 - 1.11.1
 azure_identity_cpp:
@@ -71,7 +71,8 @@ xxhash:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - libevent
+- - lz4_c
+  - libevent
   - aws_sdk_cpp
   - azure_core_cpp
   - azure_identity_cpp

--- a/.ci_support/linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs20numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs20numpy1.22python3.9.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- '*'
+- 1.11.210
 azure_core_cpp:
 - 1.11.1
 azure_identity_cpp:
@@ -45,11 +45,11 @@ liblzma_devel:
 lmdb:
 - 0.9.22
 lz4_c:
-- '1.10'
+- '1.9'
 msgpack_c:
 - '6'
 nodejs:
-- '22'
+- '20'
 numpy:
 - '1.22'
 openssl:
@@ -71,7 +71,8 @@ xxhash:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - libevent
+- - lz4_c
+  - libevent
   - aws_sdk_cpp
   - azure_core_cpp
   - azure_identity_cpp

--- a/.ci_support/linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs22numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs22numpy1.22python3.9.____cpython.yaml
@@ -45,11 +45,11 @@ liblzma_devel:
 lmdb:
 - 0.9.22
 lz4_c:
-- '1.10'
+- '1.9'
 msgpack_c:
 - '6'
 nodejs:
-- '20'
+- '22'
 numpy:
 - '1.22'
 openssl:
@@ -71,7 +71,8 @@ xxhash:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - libevent
+- - lz4_c
+  - libevent
   - aws_sdk_cpp
   - azure_core_cpp
   - azure_identity_cpp

--- a/.ci_support/linux_64_aws_sdk_cpp_lz4_c1.9nodejs20numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_aws_sdk_cpp_lz4_c1.9nodejs20numpy1.22python3.9.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.10.57
+- '*'
 azure_core_cpp:
 - 1.11.1
 azure_identity_cpp:
@@ -45,7 +45,7 @@ liblzma_devel:
 lmdb:
 - 0.9.22
 lz4_c:
-- '1.10'
+- '1.9'
 msgpack_c:
 - '6'
 nodejs:
@@ -71,7 +71,8 @@ xxhash:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - libevent
+- - lz4_c
+  - libevent
   - aws_sdk_cpp
   - azure_core_cpp
   - azure_identity_cpp

--- a/.ci_support/linux_64_aws_sdk_cpp_lz4_c1.9nodejs22numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_aws_sdk_cpp_lz4_c1.9nodejs22numpy1.22python3.9.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.10.57
+- '*'
 azure_core_cpp:
 - 1.11.1
 azure_identity_cpp:
@@ -45,7 +45,7 @@ liblzma_devel:
 lmdb:
 - 0.9.22
 lz4_c:
-- '1.10'
+- '1.9'
 msgpack_c:
 - '6'
 nodejs:
@@ -71,7 +71,8 @@ xxhash:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - libevent
+- - lz4_c
+  - libevent
   - aws_sdk_cpp
   - azure_core_cpp
   - azure_identity_cpp

--- a/README.md
+++ b/README.md
@@ -39,45 +39,45 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_aws_sdk_cpp1.10.57nodejs20numpy1.22python3.9.____cpython</td>
+              <td>linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs20numpy1.22python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19491&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp1.10.57nodejs20numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs20numpy1.22python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_aws_sdk_cpp1.10.57nodejs22numpy1.22python3.9.____cpython</td>
+              <td>linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs22numpy1.22python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19491&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp1.10.57nodejs22numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp1.10.57lz4_c1.10nodejs22numpy1.22python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_aws_sdk_cpp1.11.210nodejs20numpy1.22python3.9.____cpython</td>
+              <td>linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs20numpy1.22python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19491&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp1.11.210nodejs20numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs20numpy1.22python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_aws_sdk_cpp1.11.210nodejs22numpy1.22python3.9.____cpython</td>
+              <td>linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs22numpy1.22python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19491&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp1.11.210nodejs22numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp1.11.210lz4_c1.9nodejs22numpy1.22python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_aws_sdk_cpp_nodejs20numpy1.22python3.9.____cpython</td>
+              <td>linux_64_aws_sdk_cpp_lz4_c1.9nodejs20numpy1.22python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19491&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp_nodejs20numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp_lz4_c1.9nodejs20numpy1.22python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_aws_sdk_cpp_nodejs22numpy1.22python3.9.____cpython</td>
+              <td>linux_64_aws_sdk_cpp_lz4_c1.9nodejs22numpy1.22python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19491&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp_nodejs22numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/arcticdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_aws_sdk_cpp_lz4_c1.9nodejs22numpy1.22python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -26,6 +26,10 @@ xxhash:
 # so that potential future update in the targeted environment can be perform more easily.
 # See: https://docs.conda.io/projects/conda-build/en/stable/resources/variants.html#coupling-keys
 # "*" specifies to use the latest compatible version of the package.
+lz4_c:
+  - "1.9"
+  - "1.9"
+  - "1.9"
 libevent:
   - "2.1.10"
   - "2.1.10"
@@ -48,6 +52,7 @@ azure_storage_blobs_cpp:
   - "*"
 
 zip_keys:
+  - lz4_c
   - libevent
   - aws_sdk_cpp
   - azure_core_cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
   # Only build for Linux and Python 3.9
   skip: true  # [not linux]
   skip: true  # [not py==39]
-  number: 3
+  number: 4
 
   entry_points:
     - arcticdb_update_storage = arcticdb.scripts.update_storage:main


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Reasons:
 - `lz4_c>=1.10` is being used on conda-forge
 - The alternative environment (this branch is building package for) is using `lz4_c~=1.9`
 - [`lz4_c` has runtime requirements on minor versions](https://github.com/conda-forge/lz4-c-feedstock/blob/1771aeaed9cf4d91619cee1e822416b03e429f54/recipe/meta.yaml#L32-L33)