### PR TITLE
[ci skip] Update `abi_migration_branches` after branches' updates

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,8 @@
 bot:
   abi_migration_branches:
   - rc
-  - libevent-2.1.10
+  - 5.1.x
+  - 5.2.x
 build_platform:
   osx_arm64: osx_64
 conda_build:


### PR DESCRIPTION
Given #421, #422, #427.