### PR TITLE
[ci skip] [skip ci] Do not consider `5.1.x` and `5.2.x` for migrations

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,6 @@
 bot:
   abi_migration_branches:
   - rc
-  - 5.1.x
-  - 5.2.x
 build_platform:
   osx_arm64: osx_64
 conda_build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Reason: `5.1.x` and `5.2.x` have been published a while ago already.