### PR TITLE
Remove sparrow as run dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
 
   entry_points:
     - arcticdb_update_storage = arcticdb.scripts.update_storage:main
@@ -80,8 +80,6 @@ requirements:
     - entt
     - sparrow-devel >=1.1.2,<2
   run:
-    # TODO: fix runtime requirements of sparrow
-    - sparrow >=1.1.2,<2
   # This environment specification must be maintained in sync with the one upstream:
   # See: https://github.com/man-group/ArcticDB/blob/master/environment_unix.yml
   # See install_requires: https://github.com/man-group/ArcticDB/blob/master/setup.cfg


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The runtime dependency on `sparrow` is now automatically added by [`sparrow-devel`'s runtime requirement](https://github.com/conda-forge/sparrow-feedstock/pull/33/files#diff-ad6aed43f0cf479348ccccec8e7185c4b70582192329f11908dd22a731771702R80).